### PR TITLE
Custom capabilities

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -29,7 +29,7 @@ add_action( 'admin_menu', 'scf_add_admin_menu');
 // Admin Page: Display Submissions
 function scf_display_submissions() {
 // Check capabilities
-	if (!current_user_can('view_scf_submissions')) {
+	if (!current_user_can('view_scf_submissions') && !current_user_can('manage_options')) {
 		wp_die(__('You do not have permissions to view submissions.', 'scf'));
 	}
 	// Handle single deletion

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -28,6 +28,10 @@ add_action( 'admin_menu', 'scf_add_admin_menu');
 
 // Admin Page: Display Submissions
 function scf_display_submissions() {
+// Check capabilities
+	if (!current_user_can('view_scf_submissions')) {
+		wp_die(__('You do not have permissions to view submissions.', 'scf'));
+	}
 	// Handle single deletion
 	if (isset($_GET['delete'])) {
 		$id_to_delete = absint($_GET['delete']);

--- a/settings-page.php
+++ b/settings-page.php
@@ -15,6 +15,10 @@ add_action('admin_menu', 'scf_add_settings_page');
 
 // Render the settings page content
 function scf_render_settings_page() {
+    if (! current_user_can('manage_options')) {
+        wp_die(__('You do not have permission to access this page.', 'scf'));
+    }
+
 	?>
     <div class="wrap">
         <h1>Simple Contact Form Settings</h1>
@@ -92,4 +96,3 @@ function scf_email_body_callback() {
 	$body = get_option('scf_email_body', "You have received a new message:\n\nName: {name}\nEmail: {email}\nMessage:\n{message}\n");
 	echo '<textarea name="scf_email_body" rows="5" cols="50">' . esc_textarea($body) . '</textarea>';
 }
-

--- a/simple-contact-form.php
+++ b/simple-contact-form.php
@@ -130,3 +130,27 @@ function scf_display_dashboard_widget() {
 		echo '<p>No recent submissions found.</p>';
 	}
 }
+
+// Define custom capabilities when activated
+function scf_add_custom_capabilities() {
+//    Get the admin role
+    $admin_role = get_role('administrator');
+
+//    Add custom capabilities to the administrator role
+    if ( $admin_role ) {
+        $admin_role->add_cap('manage_scf_settings');
+        $admin_role->add_cap('view_scf_submissions');
+    }
+}
+register_activation_hook(__FILE__, 'scf_add_custom_capabilities');
+
+// Remove cap when deactivated
+function scf_remove_custom_capabilities() {
+	$admin_role = get_role('administrator');
+
+    if ( $admin_role ) {
+	    $admin_role->remove_cap('manage_scf_settings');
+	    $admin_role->remove_cap('view_scf_submissions');
+    }
+}
+register_deactivation_hook(__FILE__, 'scf_remove_custom_capabilities');


### PR DESCRIPTION
#### Custom Capabilities:
	•	view_scf_submissions: Allows users to view form submissions.
	•	manage_scf_settings: Allows users to manage the plugin’s settings.

#### Extended Admin Access:
	•	Users with the manage_options capability (typically administrators) are also granted access to view submissions, ensuring that admin users have full control over the plugin’s functionality.

#### Permissions Check:
	•	The plugin’s settings and submissions pages now check if the current user has the necessary capability before displaying content. If the user lacks permission, they will see a message informing them that they don’t have access.



Closes #6 